### PR TITLE
docs: reorganize chapters and update examples

### DIFF
--- a/docs/api-reference.org
+++ b/docs/api-reference.org
@@ -11,9 +11,9 @@ This section provides comprehensive documentation for all ε-prolog API function
 *** eprolog-define-prolog-predicate
 Define a Prolog clause (fact or rule) and add it to the database.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-prolog-predicate (name arg1 arg2 ...) goal1 goal2 ...)
-#+END_SRC
+#+end_SRC
 
 The first argument is a head term containing the predicate name and its arguments. For facts with no arguments, you can omit the parentheses: ~(eprolog-define-prolog-predicate name)~.
 
@@ -22,9 +22,9 @@ The first argument is a head term containing the predicate name and its argument
 *** eprolog-define-prolog-predicate!
 Define a Prolog clause, replacing existing clauses with the same arity.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-prolog-predicate! (name arg1 arg2 ...) goal1 goal2 ...)
-#+END_SRC
+#+end_SRC
 
 The first argument is a head term containing the predicate name and its arguments. For facts with no arguments, you can omit the parentheses: ~(eprolog-define-prolog-predicate! name)~.
 
@@ -33,25 +33,25 @@ The first argument is a head term containing the predicate name and its argument
 *** eprolog-define-lisp-predicate
 Define a predicate implemented in Emacs Lisp.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-lisp-predicate name (arg1 arg2 ...)
   ;; Lisp code returning success or failure object
   )
-#+END_SRC
+#+end_SRC
 
 ** Query Execution
 
 *** eprolog-query
 Execute an interactive Prolog query.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-query goal1 goal2 ...)
-#+END_SRC
+#+end_SRC
 
 *** eprolog-solve
 Programmatically solve goals with optional keyword callbacks.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 ;; Basic usage - just solve goals, ignore results
 (eprolog-solve goals)
 
@@ -62,25 +62,25 @@ Programmatically solve goals with optional keyword callbacks.
 (eprolog-solve goals 
   :success (lambda (bindings) ...)
   :failure (lambda () ...))
-#+END_SRC
+#+end_SRC
 
 ** DCG Support
 
 *** eprolog-define-grammar
 Define a DCG rule, adding to existing rules with the same arity.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-grammar head body-element1 body-element2 ...)
-#+END_SRC
+#+end_SRC
 
 Adds a new DCG rule without replacing existing ones. This allows multiple alternatives for the same non-terminal.
 
 *** eprolog-define-grammar!
 Define a DCG rule, replacing existing rules with the same arity.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-grammar! head body-element1 body-element2 ...)
-#+END_SRC
+#+end_SRC
 
 Similar to ~eprolog-define-grammar~ but removes existing rules for the same non-terminal with the same arity before adding the new rule. Used for redefinition or when you want only one rule for a non-terminal.
 
@@ -88,7 +88,7 @@ Similar to ~eprolog-define-grammar~ but removes existing rules for the same non-
 
 The test runner provides a convenient way to execute all tests and verify system functionality:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (defun eprolog-usage-run-all-tests ()
   "Run all ε-prolog tests and display summary."
   (interactive)
@@ -142,7 +142,7 @@ The test runner provides a convenient way to execute all tests and verify system
   "Run ε-prolog tests interactively with ERT."
   (interactive)
   (ert "eprolog-"))
-#+END_SRC
+#+end_SRC
 
 ** API Tests
 
@@ -152,7 +152,7 @@ Note: Some tests are disabled as they test APIs that don't exist or are unstable
 
 *** Predicate Definition Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-api-define-predicate ()
   "Test public predicate definition API."
   (eprolog-test--restore-builtins)
@@ -203,11 +203,11 @@ Note: Some tests are disabled as they test APIs that don't exist or are unstable
 ;;   
 ;;   (should (eprolog-test--has-solution-p '((test-lisp-pred success))))
 ;;   (should-not (eprolog-test--has-solution-p '((test-lisp-pred failure)))))
-#+END_SRC
+#+end_SRC
 
 *** Query Execution Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-api-query ()
   "Test interactive query API."
   (eprolog-test--restore-builtins)
@@ -297,11 +297,11 @@ Note: Some tests are disabled as they test APIs that don't exist or are unstable
 ;;   (let ((solutions (eprolog-solve-all (no-such-pred _x)
 ;;                      (lambda (bindings) 'should-not-happen))))
 ;;     (should (null solutions))))
-#+END_SRC
+#+end_SRC
 
 *** Error Handling Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-api-error-handling ()
   "Test API error handling."
   (eprolog-test--restore-builtins)
@@ -351,7 +351,7 @@ Note: Some tests are disabled as they test APIs that don't exist or are unstable
   (eprolog-define-predicate (special-chars |atom with spaces| +special+ /slash/))
   (should (eprolog-test--has-solution-p 
            '((special-chars |atom with spaces| +special+ /slash/)))))
-#+END_SRC
+#+end_SRC
 
 ** Conclusion
 

--- a/docs/arithmetic.org
+++ b/docs/arithmetic.org
@@ -23,7 +23,7 @@ Key concepts covered in this section:
 
 The following test demonstrates basic and complex arithmetic operations:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-basic ()
   "Test arithmetic evaluation with is/2 and mathematical functions."
   (eprolog-test--restore-builtins)
@@ -52,22 +52,22 @@ The following test demonstrates basic and complex arithmetic operations:
   (should (not (eprolog-test--has-solution-p '((is _result (+ _unbound 3))))))
   (should (not (eprolog-test--has-solution-p '((is _result (* _x _y))))))
   )
-#+END_SRC
+#+end_SRC
 
 The ~is/2~ predicate serves as the foundation for all arithmetic operations:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-is-predicate ()
   "Test basic is/2 predicate as standalone test."
   (eprolog-test--restore-builtins)
   (let ((solutions (eprolog-test--collect-solutions '((is _x (+ 2 3))))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_x (car solutions))) 5))))
-#+END_SRC
+#+end_SRC
 
 Testing various arithmetic operations demonstrates the range of mathematical capabilities:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-operations ()
   "Test basic arithmetic operations with is/2."
   (eprolog-test--restore-builtins)
@@ -82,11 +82,11 @@ Testing various arithmetic operations demonstrates the range of mathematical cap
   (let ((solutions (eprolog-test--collect-solutions '((is _x (- 100 37))))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_x (car solutions))) 63))))
-#+END_SRC
+#+end_SRC
 
 Complex expressions and mathematical functions extend the computational capabilities:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-complex ()
   "Test complex arithmetic expressions."
   (eprolog-test--restore-builtins)
@@ -97,7 +97,7 @@ Complex expressions and mathematical functions extend the computational capabili
   (let ((solutions (eprolog-test--collect-solutions '((is _x (sqrt 16))))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_x (car solutions))) 4.0))))
-#+END_SRC
+#+end_SRC
 
 ** Mathematical Predicates
 
@@ -111,7 +111,7 @@ The examples in this section illustrate:
 - Using cuts for deterministic mathematical computations
 - Building utility predicates for common mathematical operations
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-mathematical-predicates ()
   "Test mathematical predicates."
   (eprolog-test--restore-builtins)
@@ -156,11 +156,11 @@ The examples in this section illustrate:
   (let ((solutions (eprolog-test--collect-solutions '((sum-to 5 _result)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_result (car solutions))) 15))))
-#+END_SRC
+#+end_SRC
 
 Arithmetic comparisons are essential for numerical reasoning in Prolog:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-comparisons ()
   "Test arithmetic comparisons using lispp."
   (eprolog-test--restore-builtins)
@@ -183,11 +183,11 @@ Arithmetic comparisons are essential for numerical reasoning in Prolog:
   (should-not (eprolog-test--has-solution-p '((lispp (> 3 10)))))
   (should-not (eprolog-test--has-solution-p '((lispp (< 15 8)))))
   (should-not (eprolog-test--has-solution-p '((lispp (= 5 8))))))
-#+END_SRC
+#+end_SRC
 
 Custom comparison predicates demonstrate how to build domain-specific numerical logic:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-custom-comparisons ()
   "Test custom comparison predicates using lispp."
   (eprolog-test--restore-builtins)
@@ -210,11 +210,11 @@ Custom comparison predicates demonstrate how to build domain-specific numerical 
     (should (= (length solutions) 1)))
   (should-not (eprolog-test--has-solution-p '((between 12 5 10))))
   (should-not (eprolog-test--has-solution-p '((positive -5)))))
-#+END_SRC
+#+end_SRC
 
 Mathematical utility predicates like absolute value and min/max are common requirements:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-absolute-minmax ()
   "Test absolute value and min/max predicates."
   (eprolog-test--restore-builtins)
@@ -249,7 +249,7 @@ Mathematical utility predicates like absolute value and min/max are common requi
   (let ((solutions (eprolog-test--collect-solutions '((max-of 15 23 _max)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_max (car solutions))) 23))))
-#+END_SRC
+#+end_SRC
 
 ** Geometric Calculations
 
@@ -263,7 +263,7 @@ The geometric predicates presented here demonstrate:
 - Structured data representation for geometric entities (points, shapes)
 - Precision handling in floating-point geometric computations
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-geometric ()
   "Test geometric calculations."
   (eprolog-test--restore-builtins)
@@ -291,7 +291,7 @@ The geometric predicates presented here demonstrate:
   (let ((solutions (eprolog-test--collect-solutions '((circle-area 5 _area)))))
     (should (= (length solutions) 1))
     (should (< (abs (- (cdr (assoc '_area (car solutions))) 78.53975)) 0.001))))
-#+END_SRC
+#+end_SRC
 
 ** Error Handling and Edge Cases
 
@@ -310,7 +310,7 @@ The error handling coverage includes:
 
 Division by zero represents one of the most fundamental mathematical errors. These tests verify that ε-prolog properly detects and handles division by zero in various contexts, from simple direct division to complex expressions where zero divisors emerge through computation.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-division-by-zero ()
   "Test division by zero error handling."
   (eprolog-test--restore-builtins)
@@ -325,13 +325,13 @@ Division by zero represents one of the most fundamental mathematical errors. The
   ;; Complex expressions with division by zero
   (should-error (eprolog-test--has-solution-p '((is _result (/ (+ 2 3) (- 5 5))))))
   (should-error (eprolog-test--has-solution-p '((is _result (/ 1 (* 0 10)))))))
-#+END_SRC
+#+end_SRC
 
 *** Arithmetic Overflow and Underflow Tests
 
 These tests explore the behavior of ε-prolog's arithmetic system when dealing with extremely large or small numbers that may exceed the representational limits of the underlying number system. The tests verify graceful handling of numerical boundaries.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-overflow-underflow ()
   "Test arithmetic overflow and underflow conditions."
   (eprolog-test--restore-builtins)
@@ -347,13 +347,13 @@ These tests explore the behavior of ε-prolog's arithmetic system when dealing w
   ;; Test operations with very large negative numbers
   (let ((neg-large -1000000000000000000))
     (should (eprolog-test--has-solution-p `((is _result (- ,neg-large ,neg-large)))))))
-#+END_SRC
+#+end_SRC
 
 *** Type Mismatch Tests
 
 Type safety in arithmetic operations is crucial for system reliability. These tests verify that ε-prolog properly rejects arithmetic operations when non-numeric types are provided, ensuring that type errors are caught early and handled appropriately.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-type-mismatches ()
   "Test arithmetic operations with invalid types."
   (eprolog-test--restore-builtins)
@@ -373,13 +373,13 @@ Type safety in arithmetic operations is crucial for system reliability. These te
   ;; Arithmetic with complex structures (should throw errors)
   (should-error (eprolog-test--has-solution-p '((is _result (+ (foo bar) 10)))))
   (should-error (eprolog-test--has-solution-p '((is _result (/ (nested (structure)) 2))))))
-#+END_SRC
+#+end_SRC
 
 *** Invalid Expression Tests
 
 These tests examine how ε-prolog handles malformed or unusual arithmetic expressions, including edge cases in operator usage and expressions that may be syntactically valid but semantically questionable.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-invalid-expressions ()
   "Test malformed arithmetic expressions."
   (eprolog-test--restore-builtins)
@@ -402,13 +402,13 @@ These tests examine how ε-prolog handles malformed or unusual arithmetic expres
   (condition-case nil
       (should-error (eprolog-test--has-solution-p '((is _result (* (/ 5) 3)))))
     (error t)))  ;; Accept any error type
-#+END_SRC
+#+end_SRC
 
 *** Floating Point Edge Cases
 
 Floating-point arithmetic introduces special challenges related to precision, representation limits, and special values like infinity and NaN. These tests verify that ε-prolog handles floating-point edge cases consistently with the underlying Emacs Lisp numerical system.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-floating-point-edge-cases ()
   "Test floating point precision and special values."
   (eprolog-test--restore-builtins)
@@ -435,13 +435,13 @@ Floating-point arithmetic introduces special challenges related to precision, re
   (let ((solutions (eprolog-test--collect-solutions '((is _result (sqrt -1))))))
     (should (= (length solutions) 1))
     (should (isnan (cdr (assoc '_result (car solutions)))))))
-#+END_SRC
+#+end_SRC
 
 *** Advanced Mathematical Operations
 
 This subsection tests more sophisticated mathematical operations including modular arithmetic, exponentiation, and complex computational chains. These tests verify that ε-prolog correctly handles advanced mathematical functions and their edge cases.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-arithmetic-advanced-operations ()
   "Test advanced mathematical operations and edge cases."
   (eprolog-test--restore-builtins)
@@ -476,7 +476,7 @@ This subsection tests more sophisticated mathematical operations including modul
     '((is _a (+ 5 3))
       (is _b (* _a 2))
       (is _result (/ _b 4))))))
-#+END_SRC
+#+end_SRC
 
 ** Conclusion
 

--- a/docs/builtin-predicates.org
+++ b/docs/builtin-predicates.org
@@ -23,7 +23,7 @@ The type checking arsenal in ε-prolog includes:
 
 The following test demonstrates the basic type checking predicates available in ε-prolog:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-type-checking ()
   "Test type checking predicates - positive cases demonstrating correct type identification."
   (eprolog-test--restore-builtins)
@@ -75,13 +75,13 @@ The following test demonstrates the basic type checking predicates available in 
   ;; string/1 should fail for non-string types
   (should-not (eprolog-test--has-solution-p '((string foo))))
   (should-not (eprolog-test--has-solution-p '((string 123))))
-#+END_SRC
+#+end_SRC
 
 This test shows how to use the basic type checking predicates. These are fundamental for writing predicates that need to behave differently depending on the type of their arguments.
 
 The ground predicate is particularly useful for checking whether a term is fully instantiated:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-ground-predicate ()
   "Test ground term checking."
   (eprolog-test--restore-builtins)
@@ -97,7 +97,7 @@ The ground predicate is particularly useful for checking whether a term is fully
   ;; Test non-ground terms
   (should-not (eprolog-test--has-solution-p '((ground _x))))
   (should-not (eprolog-test--has-solution-p '((ground (a _x c))))))
-#+END_SRC
+#+end_SRC
 
 ** Variable Test (var) Negative Tests
 
@@ -105,7 +105,7 @@ This section provides comprehensive negative testing for the ~var/1~ predicate, 
 
 The ~var/1~ predicate is fundamental for checking the instantiation state of terms. These negative tests verify that it properly fails for all categories of non-variable terms, including bound variables, ground terms, and complex structures. This defensive testing ensures robust behavior across different data types.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-var-negative-tests ()
   "Test negative cases for var predicate."
   (eprolog-test--restore-builtins)
@@ -124,7 +124,7 @@ The ~var/1~ predicate is fundamental for checking the instantiation state of ter
   ;; Complex structures containing variables should fail
   (should-not (eprolog-test--has-solution-p '((var (a _x b)))))
   (should-not (eprolog-test--has-solution-p '((var (f _y))))))
-#+END_SRC
+#+end_SRC
 
 ** List Operations
 
@@ -140,7 +140,7 @@ Core list manipulation predicates:
 
 The following test demonstrates the versatility of list operations in Prolog:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-list-operations ()
   "Test list operation predicates from README.org examples."
   (eprolog-test--restore-builtins)
@@ -186,7 +186,7 @@ The following test demonstrates the versatility of list operations in Prolog:
     (should (member '((_A . (1)) (_B . (2 3))) solutions))
     (should (member '((_A . (1 2)) (_B . (3))) solutions))
     (should (member '((_A . (1 2 3)) (_B . ())) solutions))))
-#+END_SRC
+#+end_SRC
 
 ** Higher-order Predicates
 
@@ -202,7 +202,7 @@ Key higher-order operations covered:
 
 The following test shows how to use higher-order predicates for list transformation:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-higher-order-predicates ()
   "Test maplist higher-order predicates."
   (eprolog-test--restore-builtins)
@@ -225,7 +225,7 @@ The following test shows how to use higher-order predicates for list transformat
   ;; Test maplist length mismatch failure cases
   (should-not (eprolog-test--has-solution-p '((maplist succ (1 2) (2 3 4)))))
   (should-not (eprolog-test--has-solution-p '((maplist succ (1 2 3) (2 3))))))
-#+END_SRC
+#+end_SRC
 
 ** Type Safety and Invalid Input Tests
 
@@ -237,7 +237,7 @@ These comprehensive tests ensure that built-in predicates fail appropriately rat
 
 These tests verify that type checking predicates handle edge cases and unexpected input types correctly, ensuring they fail gracefully for inappropriate arguments while maintaining their intended semantics.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-type-checking-invalid ()
   "Test type checking predicates with invalid/unexpected inputs - negative cases and edge cases."
   (eprolog-test--restore-builtins)
@@ -277,13 +277,13 @@ These tests verify that type checking predicates handle edge cases and unexpecte
   (should-not (eprolog-test--has-solution-p '((string atom))))
   (should-not (eprolog-test--has-solution-p '((string (a b)))))    ; list is not string
   (should-not (eprolog-test--has-solution-p '((string ()))))      ; empty list is not string
-#+END_SRC
+#+end_SRC
 
 *** List Operations with Invalid Structures
 
 This subsection tests how list manipulation predicates handle non-list inputs and malformed data structures, ensuring robust failure behavior when presented with inappropriate arguments.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-list-operations-invalid ()
   "Test list operations with non-list and invalid inputs."
   (eprolog-test--restore-builtins)
@@ -304,13 +304,13 @@ This subsection tests how list manipulation predicates handle non-list inputs an
   
   ;; Test with mixed valid/invalid structures
   (should-not (eprolog-test--has-solution-p '((append ((1 2) (3 4) not-list) _result)))))
-#+END_SRC
+#+end_SRC
 
 *** Maplist with Invalid Predicates
 
 These tests verify the error handling capabilities of higher-order predicates when provided with invalid predicate arguments, undefined predicates, or mismatched arities.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-maplist-invalid ()
   "Test maplist with undefined and invalid predicates."
   (eprolog-test--restore-builtins)
@@ -331,13 +331,13 @@ These tests verify the error handling capabilities of higher-order predicates wh
   (eprolog-define-predicate (test-pred _x))
   (should-not (eprolog-test--has-solution-p '((maplist test-pred atom))))
   (should-not (eprolog-test--has-solution-p '((maplist test-pred 123)))))
-#+END_SRC
+#+end_SRC
 
 *** Ground Predicate Edge Cases
 
 This subsection thoroughly tests the ~ground/1~ predicate with complex nested structures, deeply nested terms, and boundary cases to ensure it correctly identifies the instantiation status of complex data structures.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-ground-edge-cases ()
   "Test ground predicate with complex and edge case structures."
   (eprolog-test--restore-builtins)
@@ -362,13 +362,13 @@ This subsection thoroughly tests the ~ground/1~ predicate with complex nested st
     (should (= (length solutions) 1)))
   (let ((solutions (eprolog-test--collect-solutions '((ground (empty-list ()))))))
     (should (= (length solutions) 1))))
-#+END_SRC
+#+end_SRC
 
 *** Empty List Handling
 
 Empty lists represent a fundamental boundary case in list processing. These tests verify that all list operations handle empty lists correctly, maintaining logical consistency and proper failure semantics when appropriate.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-builtin-empty-list-handling ()
   "Test operations with empty lists and edge cases."
   (eprolog-test--restore-builtins)
@@ -396,4 +396,4 @@ Empty lists represent a fundamental boundary case in list processing. These test
   
   ;; Test decomposition of empty list
   (should-not (eprolog-test--has-solution-p '((= () (_head . _tail))))))
-#+END_SRC
+#+end_SRC

--- a/docs/control-flow.org
+++ b/docs/control-flow.org
@@ -20,7 +20,7 @@ Core control predicates covered:
 - ~!/0~ (cut): The commitment operator—prevents backtracking and commits to current choice
 - ~not/1~: Negation as failure—succeeds when its argument fails, implementing logical negation
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-basic-predicates ()
   "Test basic control flow predicates."
   (eprolog-test--restore-builtins)
@@ -36,11 +36,11 @@ Core control predicates covered:
   (let ((solutions (eprolog-test--collect-solutions '((not fail)))))
     (should (= (length solutions) 1)))
   (should-not (eprolog-test--has-solution-p '((not true)))))
-#+END_SRC
+#+end_SRC
 
 This is the main control predicate test that covers all basic control flow operations. Additionally, here are more focused individual tests:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-predicates ()
   "Test control predicates."
   (eprolog-test--restore-builtins)
@@ -55,20 +55,20 @@ This is the main control predicate test that covers all basic control flow opera
   (let ((solutions (eprolog-test--collect-solutions '((not fail)))))
     (should (= (length solutions) 1)))
   (should-not (eprolog-test--has-solution-p '((not true)))))
-#+END_SRC
+#+end_SRC
 
 The fail predicate serves a specific purpose in forcing backtracking:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-fail-predicate ()
   "Test the fail predicate."
   (eprolog-test--restore-builtins)
   (should-not (eprolog-test--has-solution-p '((fail)))))
-#+END_SRC
+#+end_SRC
 
 The cut operator provides individual testing separate from the more complex cut semantics:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-cut-predicate ()
   "Test cut (!) behavior as standalone predicate."
   (eprolog-test--restore-builtins)
@@ -82,11 +82,11 @@ The cut operator provides individual testing separate from the more complex cut 
   (let ((solutions (eprolog-test--collect-solutions '((test-cut _x)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_x (car solutions))) 'a))))
-#+END_SRC
+#+end_SRC
 
 The call predicate enables meta-programming:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-call-predicate ()
   "Test the call predicate."
   (eprolog-test--restore-builtins)
@@ -97,7 +97,7 @@ The call predicate enables meta-programming:
   (let ((solutions (eprolog-test--collect-solutions '((call = _x 42) (= _x 42)))))
     (should (= (length solutions) 1))
     (should (= (cdr (assoc '_x (car solutions))) 42))))
-#+END_SRC
+#+end_SRC
 
 ** Logical Operators
 
@@ -111,7 +111,7 @@ Key logical operators and their behaviors:
 - ~if/2-3~: Conditional execution—implements if-then and if-then-else patterns with commitment semantics
 - Interaction with backtracking: How these operators manage choice points and solution exploration
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-logical-predicates ()
   "Test logical conjunction and disjunction predicates."
   (eprolog-test--restore-builtins)
@@ -141,11 +141,11 @@ Key logical operators and their behaviors:
     (should (= (length solutions) 1)))
   (let ((solutions (eprolog-test--collect-solutions '((if fail fail true)))))
     (should (= (length solutions) 1))))
-#+END_SRC
+#+end_SRC
 
 Conditional execution provides if-then-else semantics in a logical context:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-if-then-else ()
   "Test conditional predicate (if) as standalone test."
   (eprolog-test--restore-builtins)
@@ -157,7 +157,7 @@ Conditional execution provides if-then-else semantics in a logical context:
     (should (= (length solutions) 1)))
   (let ((solutions (eprolog-test--collect-solutions '((if fail then-pred else-pred)))))
     (should (= (length solutions) 1))))
-#+END_SRC
+#+end_SRC
 
 ** Meta-predicates
 
@@ -170,7 +170,7 @@ Meta-predicates treat other predicates as data, enabling powerful metaprogrammin
 
 This capability enables sophisticated programming patterns where the structure of queries can be determined at runtime.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-metacall-predicates ()
   "Test meta-call predicates."
   (eprolog-test--restore-builtins)
@@ -186,13 +186,13 @@ This capability enables sophisticated programming patterns where the structure o
     (should (= (cdr (assoc '_x (car solutions))) 42)))
   (let ((solutions (eprolog-test--collect-solutions '((call = foo foo)))))
     (should (= (length solutions) 1))))
-#+END_SRC
+#+end_SRC
 
 ** Call Predicate Negative Tests
 
 The call predicate should fail with undefined predicates, invalid arguments, and malformed terms:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-call-negative-tests ()
   "Test negative cases for call predicate."
   (eprolog-test--restore-builtins)
@@ -211,7 +211,7 @@ The call predicate should fail with undefined predicates, invalid arguments, and
   (eprolog-define-predicate! (always-fails) (fail))
   (should-not (eprolog-test--has-solution-p '((call always-fails))))
   (should-not (eprolog-test--has-solution-p '((call = foo bar)))))
-#+END_SRC
+#+end_SRC
 
 ** Cut and Backtracking Control
 
@@ -226,7 +226,7 @@ Key aspects of cut and backtracking control:
 - Semantic considerations: How cut affects the logical meaning of your programs
 - Common cut patterns: Green cuts (optimizations) vs. red cuts (changing logical meaning)
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-cut-semantics ()
   "Test cut (!) semantics."
   (eprolog-test--restore-builtins)
@@ -248,11 +248,11 @@ Key aspects of cut and backtracking control:
   (let ((solutions (eprolog-test--collect-solutions '((first-choice _x)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_x (car solutions))) 'a))))
-#+END_SRC
+#+end_SRC
 
 The repeat predicate creates infinite choice points, useful for implementing loops:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-repeat-predicate ()
   "Test repeat predicate for infinite choice points."
   (eprolog-test--restore-builtins)
@@ -267,13 +267,13 @@ The repeat predicate creates infinite choice points, useful for implementing loo
     (let ((solutions (eprolog-test--collect-solutions '((test-repeat-usage)))))
       (should (= (length solutions) 1)))
     (should (= counter 3))))
-#+END_SRC
+#+end_SRC
 
 ** Cut (!) Negative Tests
 
 The cut predicate controls backtracking, and these tests verify proper failure behavior in cut-controlled branches:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-cut-negative-tests ()
   "Test negative cases for cut (!) predicate."
   (eprolog-test--restore-builtins)
@@ -303,7 +303,7 @@ The cut predicate controls backtracking, and these tests verify proper failure b
     (fail))
   
   (should-not (eprolog-test--has-solution-p '((cut-branch-fail)))))
-#+END_SRC
+#+end_SRC
 
 ** Advanced Control Flow Error Cases
 
@@ -315,7 +315,7 @@ Robust error handling in control flow is crucial for building reliable logical p
 
 These tests explore the behavior of deeply nested control structures, verifying that the system can handle complex nested logical expressions without stack overflow or performance degradation.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-deep-nesting ()
   "Test deeply nested control structures."
   (eprolog-test--restore-builtins)
@@ -344,13 +344,13 @@ These tests explore the behavior of deeply nested control structures, verifying 
     '((if true
           (if true
               (if fail true fail)))))))
-#+END_SRC
+#+end_SRC
 
 *** Meta-predicate Error Handling
 
 This subsection tests the error handling capabilities of meta-predicates like ~call/1~, ensuring they properly handle malformed goals, undefined predicates, and invalid argument types.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-meta-predicate-errors ()
   "Test error handling in meta-predicates like call/1."
   (eprolog-test--restore-builtins)
@@ -371,13 +371,13 @@ This subsection tests the error handling capabilities of meta-predicates like ~c
   
   ;; Test call with unbound variables that can't be resolved
   (should-not (eprolog-test--has-solution-p '((call _undefined_goal)))))
-#+END_SRC
+#+end_SRC
 
 *** Cut Interaction Edge Cases
 
 This subsection explores complex interactions between the cut operator and other control flow constructs, testing how cuts behave within nested logical structures and conditional expressions.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-cut-interaction-edge-cases ()
   "Test cut behavior in complex interaction scenarios."
   (eprolog-test--restore-builtins)
@@ -406,13 +406,13 @@ This subsection explores complex interactions between the cut operator and other
   (let ((solutions (eprolog-test--collect-solutions '((cut-in-if success)))))
     (should (= (length solutions) 1)))
   (should-not (eprolog-test--has-solution-p '((cut-in-if failure)))))
-#+END_SRC
+#+end_SRC
 
 *** Logical Operator Edge Cases
 
 These tests verify the robustness of logical operators when presented with invalid arguments, edge cases in boolean logic, and complex nested combinations that stress the evaluation system.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-logical-operators-edge-cases ()
   "Test edge cases in logical operators."
   (eprolog-test--restore-builtins)
@@ -437,13 +437,13 @@ These tests verify the robustness of logical operators when presented with inval
     '((or (and fail true)
           (and true (or fail true)))))))
     (should (= (length solutions) 1))))
-#+END_SRC
+#+end_SRC
 
 *** Or Predicate Variable Binding Tests
 
 These tests verify that the ~or~ predicate correctly handles variable bindings across disjunctive branches, ensuring that each branch can contribute variable bindings independently without interference.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-or-variable-binding ()
   "Test or predicate variable binding behavior across disjunctive branches."
   (eprolog-test--restore-builtins)
@@ -478,9 +478,9 @@ These tests verify that the ~or~ predicate correctly handles variable bindings a
       ;; From q(_y): y should be bound to 1, 2 and x should be unbound (equal to the variable)
       (should (member 1 y-bindings))
       (should (member 2 y-bindings)))))
-#+END_SRC
+#+end_SRC
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-control-or-variable-binding-nested ()
   "Test or predicate variable binding behavior across disjunctive branches."
   (eprolog-test--restore-builtins)
@@ -517,7 +517,7 @@ These tests verify that the ~or~ predicate correctly handles variable bindings a
       ;; From q(_y): y should be bound to 1, 2 and x should be unbound (equal to the variable)
       (should (member 1 y-bindings))
       (should (member 2 y-bindings)))))
-#+END_SRC
+#+end_SRC
 
 
 ** Conclusion

--- a/docs/core-prolog.org
+++ b/docs/core-prolog.org
@@ -25,7 +25,7 @@ Core concepts in this section:
 
 This test demonstrates the fundamental pattern of Prolog programming: starting with basic facts and building complex relationships through rules. We create a family tree and then derive grandparent relationships from parent facts:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-basic-facts-and-rules ()
   "Test basic fact and rule definition from README.org examples."
   (eprolog-test--restore-builtins)
@@ -61,11 +61,11 @@ This test demonstrates the fundamental pattern of Prolog programming: starting w
   
   ;; More tests for verification
   (should-not (eprolog-test--has-solution-p '((parent alice bob)))))
-#+END_SRC
+#+end_SRC
 
 This test shows how to dynamically define predicates with various arities:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-predicate-definition-tests ()
   "Test different ways of defining predicates."
   (eprolog-test--restore-builtins)
@@ -83,11 +83,11 @@ This test shows how to dynamically define predicates with various arities:
   ;; Test failure cases
   (should-not (eprolog-test--has-solution-p '((one-arity bar))))
   (should-not (eprolog-test--has-solution-p '((two-arity bar foo)))))
-#+END_SRC
+#+end_SRC
 
 This test demonstrates predicate replacement:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-predicate-replacement ()
   "Test predicate replacement with same arity."
   (eprolog-test--restore-builtins)
@@ -106,11 +106,11 @@ This test demonstrates predicate replacement:
   (should-not (eprolog-test--has-solution-p '((replaceable-pred old-value))))
   (should-not (eprolog-test--has-solution-p '((replaceable-pred another-value))))
   (should (= (length (eprolog-test--collect-solutions '((replaceable-pred _x)))) 1)))
-#+END_SRC
+#+end_SRC
 
 This test demonstrates a family tree from the Sazae-san manga/anime:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-family-tree-sazae-san ()
   "Test family tree with Sazae-san family."
   (eprolog-test--restore-builtins)
@@ -142,7 +142,7 @@ This test demonstrates a family tree from the Sazae-san manga/anime:
   (let ((grandchildren (eprolog-test--collect-solutions '((grandparent namihei _x)))))
     (should (= (length grandchildren) 1))
     (should (member '((_x . tarao)) grandchildren))))
-#+END_SRC
+#+end_SRC
 
 ** Unification and Equality
 
@@ -169,7 +169,7 @@ Key unification concepts:
 
 Understanding the difference between unification (=) and strict equality (==) is crucial for effective Prolog programming. While unification creates bindings, strict equality only tests existing values without creating new bindings.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-unification-and-equality ()
   "Test unification and strict equality from README.org."
   (eprolog-test--restore-builtins)
@@ -192,13 +192,13 @@ Understanding the difference between unification (=) and strict equality (==) is
   (should (eprolog-test--has-solution-p '((= (person john 30) (person john 30)))))
   (should (eprolog-test--has-solution-p '((= (person _name 30) (person john 30)))))
   (should-not (eprolog-test--has-solution-p '((= (person john 30) (person jane 30))))))
-#+END_SRC
+#+end_SRC
 
 ** Unification (=) Negative Tests
 
 These tests verify that unification properly fails in cases where terms cannot be made equal:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-unification-negative-tests ()
   "Test cases where unification should fail."
   (eprolog-test--restore-builtins)
@@ -226,13 +226,13 @@ These tests verify that unification properly fails in cases where terms cannot b
   ;; Conflicting variable bindings
   (should-not (eprolog-test--has-solution-p '((= _x 1) (= _x 2))))
   (should-not (eprolog-test--has-solution-p '((= (f _x _x) (f 1 2))))))
-#+END_SRC
+#+end_SRC
 
 ** Strict Equality (==) Negative Tests
 
 These tests verify that strict equality properly fails when terms are not already identical:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-strict-equality-negative-tests ()
   "Test cases where strict equality should fail."
   (eprolog-test--restore-builtins)
@@ -258,7 +258,7 @@ These tests verify that strict equality properly fails when terms are not alread
   ;; Variables bound to different values
   (should-not (eprolog-test--has-solution-p '((= _x 1) (= _y 2) (== _x _y))))
   (should-not (eprolog-test--has-solution-p '((= _x foo) (= _y bar) (== _x _y)))))
-#+END_SRC
+#+end_SRC
 
 ** Variable Unification Edge Cases
 
@@ -266,7 +266,7 @@ This section delves into the sophisticated aspects of variable unification, expl
 
 Variable unification in Prolog involves subtle behaviors that distinguish it from simple assignment or equality checking. Understanding these edge cases is crucial for writing robust logic programs and avoiding common pitfalls in variable handling.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-anonymous-variables ()
   "Test anonymous variable behavior."
   (eprolog-test--restore-builtins)
@@ -284,11 +284,11 @@ Variable unification in Prolog involves subtle behaviors that distinguish it fro
   (eprolog-define-predicate (triple a b c))
   (eprolog-define-predicate (triple x y z))
   (should (= (length (eprolog-test--collect-solutions '((triple _ _ _)))) 2)))
-#+END_SRC
+#+end_SRC
 
 This test demonstrates more complex unification scenarios:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-variable-unification-advanced ()
   "Test advanced variable unification patterns."
   (eprolog-test--restore-builtins)
@@ -355,13 +355,13 @@ This test demonstrates more complex unification scenarios:
     ;; Should have a solution with john as the name
     (let ((person-binding (cdr (assoc '_person (car solutions)))))
       (should (member 'john person-binding)))))
-#+END_SRC
+#+end_SRC
 
 ** Occurs Check
 
 The occurs check prevents the creation of infinite structures during unification:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-occurs-check ()
   "Test occurs check in unification."
   (eprolog-test--restore-builtins)
@@ -370,7 +370,7 @@ The occurs check prevents the creation of infinite structures during unification
   (let ((eprolog-occurs-check t))
     (should-not (eprolog-test--has-solution-p '((= _x (_x)))))
     (should-not (eprolog-test--has-solution-p '((= _x (f _x)))))))
-#+END_SRC
+#+end_SRC
 
 ** Core Engine Internal Tests
 
@@ -378,7 +378,7 @@ These tests verify the internal engine functions that power ε-prolog. While the
 
 *** Variable Handling Functions
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-variable-handling ()
   "Test core variable handling functions."
   (eprolog-test--restore-builtins)
@@ -444,13 +444,13 @@ These tests verify the internal engine functions that power ε-prolog. While the
   (should-not (eprolog--ground-p '_x))
   (should-not (eprolog--ground-p '(foo _x)))
   (should-not (eprolog--ground-p '(nested (structure _var)))))
-#+END_SRC
+#+end_SRC
 
 *** Substitution and Binding Functions
 
 This subsection tests the internal functions responsible for variable substitution and binding management—the low-level mechanisms that implement unification and maintain variable consistency throughout query execution.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-substitution ()
   "Test substitution of bindings in terms."
   (eprolog-test--restore-builtins)
@@ -488,11 +488,11 @@ This subsection tests the internal functions responsible for variable substituti
     (should (equal (eprolog--lookup-variable '_x bindings) '_y))
     (should (equal (eprolog--lookup-variable '_y bindings) '_z))
     (should (equal (eprolog--lookup-variable '_z bindings) 'final))))
-#+END_SRC
+#+end_SRC
 
 *** Variable Renaming Functions
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-rename-vars ()
   "Test variable renaming functionality."
   (eprolog-test--restore-builtins)
@@ -516,7 +516,7 @@ This subsection tests the internal functions responsible for variable substituti
       (should (equal (cadr renamed) (caddr renamed)))
       ;; Different variables should get different names
       (should-not (equal (cadr renamed) (cadddr renamed))))))
-#+END_SRC
+#+end_SRC
 
 ** Resource Exhaustion and Performance Tests
 
@@ -528,7 +528,7 @@ Understanding how a Prolog system behaves under stress is crucial for building r
 
 These tests explore the system's behavior with deeply recursive predicates, testing stack limits and the graceful handling of potential stack overflow conditions.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-deep-recursion-limits ()
   "Test deep recursion and stack overflow protection."
   (eprolog-test--restore-builtins)
@@ -549,13 +549,13 @@ These tests explore the system's behavior with deeply recursive predicates, test
   (condition-case nil
       (eprolog-test--has-solution-p '((countdown 10000 _result)))
     (error t))) ;; Accept either success or controlled failure
-#+END_SRC
+#+end_SRC
 
 *** Very Large Data Structure Tests
 
 These tests verify the system's handling of large terms, deeply nested structures, and complex data that may push memory and processing limits.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-large-data-structures ()
   "Test handling of very large terms and lists."
   (eprolog-test--restore-builtins)
@@ -578,13 +578,13 @@ These tests verify the system's handling of large terms, deeply nested structure
   ;; Test unification with moderately large structures
   (let ((big-term (make-list 10 '(complex (nested (structure a b c))))))
     (should (eprolog-test--has-solution-p `((= _x ,big-term))))))
-#+END_SRC
+#+end_SRC
 
 *** Memory Stress Tests
 
 These tests stress the memory management systems by creating many facts, complex variable binding chains, and large knowledge bases to verify stable operation under memory pressure.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-memory-stress ()
   "Test memory usage under stress conditions."
   (eprolog-test--restore-builtins)
@@ -606,7 +606,7 @@ These tests stress the memory management systems by creating many facts, complex
     
     ;; This creates a chain of 10 variable bindings
     (should (eprolog-test--has-solution-p (reverse query)))))
-#+END_SRC
+#+end_SRC
 
 ** Edge Cases and Special Character Handling
 
@@ -618,7 +618,7 @@ Comprehensive edge case testing ensures that ε-prolog handles unusual but valid
 
 These tests verify that ε-prolog correctly handles atoms with special characters and practical naming conventions commonly encountered in real-world usage.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-special-characters ()
   "Test handling of practical special characters in atom names."
   (eprolog-test--restore-builtins)
@@ -638,13 +638,13 @@ These tests verify that ε-prolog correctly handles atoms with special character
   ;; Test underscore and dash in atom names (common in practice)
   (eprolog-define-predicate (underscore-test my_atom another-atom))
   (should (eprolog-test--has-solution-p '((underscore-test my_atom another-atom)))))
-#+END_SRC
+#+end_SRC
 
 *** Empty and Boundary Value Tests
 
 This subsection tests the system's handling of empty structures, boundary numeric values, and minimal valid inputs to ensure robust behavior at the edges of the valid input space.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-empty-and-boundary-values ()
   "Test handling of empty inputs and boundary values."
   (eprolog-test--restore-builtins)
@@ -673,13 +673,13 @@ This subsection tests the system's handling of empty structures, boundary numeri
         (min-int most-negative-fixnum))
     (should (eprolog-test--has-solution-p `((= _x ,max-int))))
     (should (eprolog-test--has-solution-p `((= _x ,min-int))))))
-#+END_SRC
+#+end_SRC
 
 *** Zero and Null Value Handling
 
 This subsection explores the distinct treatment of various "empty" or "null" values in ε-prolog, testing how the system distinguishes between zero, nil, null atoms, and empty lists.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-core-zero-null-handling ()
   "Test handling of zero, null, and nil values."
   (eprolog-test--restore-builtins)
@@ -705,4 +705,4 @@ This subsection explores the distinct treatment of various "empty" or "null" val
   
   ;; Test list operations with nil/empty lists
   (should (eprolog-test--has-solution-p '((= _empty ())))))
-#+END_SRC
+#+end_SRC

--- a/docs/dcg.org
+++ b/docs/dcg.org
@@ -33,18 +33,18 @@ DCG rules are defined using specialized macros that automatically handle the tra
 **** eprolog-define-grammar
 Define a DCG rule, adding to existing rules with the same arity.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-grammar head body-element1 body-element2 ...)
-#+END_SRC
+#+end_SRC
 
 Adds a new DCG rule without replacing existing ones. This allows multiple alternatives for the same non-terminal.
 
 **** eprolog-define-grammar!
 Define a DCG rule, replacing existing rules with the same arity.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-grammar! head body-element1 body-element2 ...)
-#+END_SRC
+#+end_SRC
 
 Similar to ~eprolog-define-grammar~ but removes existing rules for the same non-terminal with the same arity before adding the new rule. Used for redefinition or when you want only one rule for a non-terminal.
 
@@ -55,13 +55,13 @@ The phrase predicates provide the interface between DCG rules and the input/outp
 **** phrase/2 and phrase/3
 Parse or generate using DCG rules.
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 ;; Parse complete input
 (eprolog-query (phrase non-terminal input-list))
 
 ;; Parse with remainder  
 (eprolog-query (phrase non-terminal input-list remainder))
-#+END_SRC
+#+end_SRC
 
 ~phrase/2~ succeeds if the non-terminal can parse the entire input list.
 ~phrase/3~ succeeds if the non-terminal can parse a prefix, with the remainder unified with the third argument.
@@ -72,7 +72,7 @@ These examples demonstrate the practical application of DCG notation, showing ho
 
 **** Basic Grammar Definition
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 ;; Define a simple grammar for sentences
 (eprolog-define-grammar! s np vp)           ; sentence → noun phrase + verb phrase
 (eprolog-define-grammar! np det noun)       ; noun phrase → determiner + noun  
@@ -85,11 +85,11 @@ These examples demonstrate the practical application of DCG notation, showing ho
 (eprolog-define-grammar noun "dog")
 (eprolog-define-grammar! verb "chases")
 (eprolog-define-grammar verb "sees")
-#+END_SRC
+#+end_SRC
 
 **** Parsing with DCG
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 ;; Parse complete sentences
 (eprolog-query (phrase s ("the" "cat" "chases" "a" "dog")))
 ;; Succeeds - valid sentence
@@ -103,7 +103,7 @@ These examples demonstrate the practical application of DCG notation, showing ho
 ;; Parse with remaining tokens
 (eprolog-query (phrase s ("the" "cat" "chases" "a" "dog" "quickly") _rest))
 ;; _rest = ("quickly") - parses sentence, leaves remainder
-#+END_SRC
+#+end_SRC
 
 *** DCG Best Practices
 
@@ -112,33 +112,33 @@ Understanding common pitfalls and best practices is essential for writing effici
 **** Left Recursion
 Avoid left recursion in DCG rules as it can cause infinite loops:
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 ;; BAD - left recursive
 (eprolog-define-grammar expr expr "+" term)
 
 ;; GOOD - right recursive  
 (eprolog-define-grammar expr term "+" expr)
 (eprolog-define-grammar expr term)
-#+END_SRC
+#+end_SRC
 
 **** Deterministic Parsing
 Use cut (!) to make parsing deterministic when appropriate:
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 (eprolog-define-grammar! statement declarative-stmt !)
 (eprolog-define-grammar statement question-stmt)
-#+END_SRC
+#+end_SRC
 
 **** Semantic Constraints
 Use semantic actions (@ ...) for constraints that don't consume input:
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_SRC emacs-lisp :eval never :tangle no
 ;; Ensure number agreement
 (eprolog-define-grammar (s _num) 
   (np _num) 
   (@ (atom _num))           ; Constraint: _num must be bound
   (vp _num))
-#+END_SRC
+#+end_SRC
 
 ** Basic Grammar Operations
 
@@ -155,7 +155,7 @@ The examples in this section progress from elementary concepts to practical pars
 
 The following test introduces basic DCG concepts with a simple grammar:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-basic ()
   "Test basic DCG functionality."
   (eprolog-test--restore-builtins)
@@ -167,11 +167,11 @@ The following test introduces basic DCG concepts with a simple grammar:
   (should (eprolog-test--has-solution-p '((phrase sentence ("cat" "runs")))))
   (should (eprolog-test--has-solution-p '((phrase sentence ("dog" "runs")))))
   (should-not (eprolog-test--has-solution-p '((phrase sentence ("cat" "sleeps"))))))
-#+END_SRC
+#+end_SRC
 
 A more complete grammar demonstrates how DCGs can parse natural language structures:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-basic-grammar ()
   "Test basic DCG grammar definition and parsing."
   (eprolog-test--restore-builtins)
@@ -193,11 +193,11 @@ A more complete grammar demonstrates how DCGs can parse natural language structu
   
   ;; Test parsing invalid sentences
   (should-not (eprolog-test--has-solution-p '((phrase s ("cat" "the" "chases"))))))
-#+END_SRC
+#+end_SRC
 
 DCGs can also parse partial input, returning the unparsed remainder:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-parsing-with-remainder ()
   "Test DCG parsing with remainder."
   (eprolog-test--restore-builtins)
@@ -215,7 +215,7 @@ DCGs can also parse partial input, returning the unparsed remainder:
                     '((phrase s ("the" "cat" "chases" "the" "cat" "quickly") _rest)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_rest (car solutions))) '("quickly")))))
-#+END_SRC
+#+end_SRC
 
 ** Advanced DCG Features
 
@@ -223,7 +223,7 @@ This section explores sophisticated DCG capabilities that enable complex linguis
 
 Understanding these advanced features is crucial for building real-world parsers that handle the complexity and variability of natural and formal languages. These capabilities allow DCGs to express linguistic constraints, build structured representations, and implement sophisticated parsing strategies.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-epsilon-productions ()
   "Test DCG epsilon (empty) productions."
   (eprolog-test--restore-builtins)
@@ -238,11 +238,11 @@ Understanding these advanced features is crucial for building real-world parsers
   
   (should (eprolog-test--has-solution-p '((phrase np ("the" "cat")))))
   (should (eprolog-test--has-solution-p '((phrase np ("the" "big" "cat"))))))
-#+END_SRC
+#+end_SRC
 
 DCGs with arguments enable grammatical agreement and semantic processing:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-with-args ()
   "Test DCG with arguments."
   (eprolog-test--restore-builtins)
@@ -262,11 +262,11 @@ DCGs with arguments enable grammatical agreement and semantic processing:
   ;; Test mismatched agreement
   (should-not (eprolog-test--has-solution-p '((phrase (noun singular) ("cats")))))
   (should-not (eprolog-test--has-solution-p '((phrase (noun plural) ("cat"))))))
-#+END_SRC
+#+end_SRC
 
 Semantic actions in DCGs allow you to build parse trees or perform computations during parsing:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-semantic-actions ()
   "Test DCG semantic actions."
   (eprolog-test--restore-builtins)
@@ -284,11 +284,11 @@ Semantic actions in DCGs allow you to build parse trees or perform computations 
   
   (should (eprolog-test--has-solution-p '((phrase (s _) ("a" "cat" "chases" "some" "cats")))))
   (should-not (eprolog-test--has-solution-p '((phrase (s _) ("a" "cat" "chase" "some" "cats"))))))
-#+END_SRC
+#+end_SRC
 
 Cut operations in DCGs provide control over parsing alternatives:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-cut-operations ()
   "Test DCG cut operations."
   (eprolog-test--restore-builtins)
@@ -301,13 +301,13 @@ Cut operations in DCGs provide control over parsing alternatives:
   (eprolog-define-grammar! s "test")
   
   (should (eprolog-test--has-solution-p '((phrase statement ("test" "."))))))
-#+END_SRC
+#+end_SRC
 
 ** Grammar Generation
 
 DCGs work bidirectionally - they can generate sentences as well as parse them:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-generation ()
   "Test DCG sentence generation."
   (eprolog-test--restore-builtins)
@@ -324,11 +324,11 @@ DCGs work bidirectionally - they can generate sentences as well as parse them:
   (let ((solutions (eprolog-test--collect-solutions '((phrase s _sentence)))))
     (should (> (length solutions) 0))
     (should (equal (cdr (assoc '_sentence (car solutions))) '("the" "cat" "runs")))))
-#+END_SRC
+#+end_SRC
 
 Length-constrained generation demonstrates how to combine DCGs with other predicates:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-length-constrained-generation ()
   "Test DCG generation with length constraints."
   (eprolog-test--restore-builtins)
@@ -347,7 +347,7 @@ Length-constrained generation demonstrates how to combine DCGs with other predic
   (let ((solutions (eprolog-test--collect-solutions '((phrase s2 _sentence) (length _sentence 3)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_sentence (car solutions))) '("a" "cat" "runs")))))
-#+END_SRC
+#+end_SRC
 
 ** Complex Grammar Applications
 
@@ -355,7 +355,7 @@ This section demonstrates the application of DCGs to sophisticated parsing chall
 
 The applications presented here represent common parsing scenarios that arise in language processing, compiler construction, and data processing tasks. Each example builds upon the fundamental DCG concepts to create practical, reusable parsing solutions.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-arithmetic-expressions ()
   "Test arithmetic expression parsing with DCG."
   (eprolog-test--restore-builtins)
@@ -378,11 +378,11 @@ The applications presented here represent common parsing scenarios that arise in
   (should (eprolog-test--has-solution-p '((phrase expr ("2")))))
   (should (eprolog-test--has-solution-p '((phrase expr ("2" "+" "3" "*" "4")))))
   (should (eprolog-test--has-solution-p '((phrase expr ("(" "2" "+" "3" ")" "*" "4"))))))
-#+END_SRC
+#+end_SRC
 
 Nested structure parsing showcases DCGs' recursive capabilities:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-nested-structures ()
   "Test nested structure parsing with DCG."
   (eprolog-test--restore-builtins)
@@ -396,11 +396,11 @@ Nested structure parsing showcases DCGs' recursive capabilities:
   (should (eprolog-test--has-solution-p '((phrase parens ("(" ")")))))
   (should (eprolog-test--has-solution-p '((phrase parens ("(" "(" ")" "(" ")" ")")))))
   (should-not (eprolog-test--has-solution-p '((phrase parens ("(" "(" ")"))))))
-#+END_SRC
+#+end_SRC
 
 CSV-style parsing demonstrates practical text processing:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-csv-parsing ()
   "Test CSV-style parsing with DCG."
   (eprolog-test--restore-builtins)
@@ -416,7 +416,7 @@ CSV-style parsing demonstrates practical text processing:
   (should (eprolog-test--has-solution-p '((phrase csv-list ("apple")))))
   (should (eprolog-test--has-solution-p '((phrase csv-list ("apple" "," "banana")))))
   (should (eprolog-test--has-solution-p '((phrase csv-list ("apple" "," "banana" "," "cherry"))))))
-#+END_SRC
+#+end_SRC
 
 ** DCG Error Handling and Edge Cases
 
@@ -428,7 +428,7 @@ Comprehensive error handling testing is crucial for building reliable parsing sy
 
 These tests explore how the DCG system handles invalid grammar definitions, undefined non-terminals, and improper argument structures, ensuring robust failure behavior.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-malformed-grammar ()
   "Test error handling with malformed DCG rules."
   (eprolog-test--restore-builtins)
@@ -449,13 +449,13 @@ These tests explore how the DCG system handles invalid grammar definitions, unde
   (condition-case nil
       (should-error (eprolog-test--has-solution-p '((phrase test-rule "not-list"))))
     (error t)))
-#+END_SRC
+#+end_SRC
 
 *** Empty Input and Edge Cases
 
 This subsection tests the parsing system's behavior with empty inputs, minimal valid inputs, and boundary conditions that might expose edge cases in the parsing logic.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-empty-input-edge-cases ()
   "Test DCG parsing with empty and edge case inputs."
   (eprolog-test--restore-builtins)
@@ -479,13 +479,13 @@ This subsection tests the parsing system's behavior with empty inputs, minimal v
   (eprolog-define-grammar! two-words word word)
   (should-not (eprolog-test--has-solution-p '((phrase two-words ("test")))))
   (should (eprolog-test--has-solution-p '((phrase two-words ("test" "test"))))))
-#+END_SRC
+#+end_SRC
 
 *** Large Input Stress Test
 
 These tests evaluate the DCG system's performance and stability when processing very large input streams, testing resource limits and graceful degradation under memory pressure.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-large-input-stress ()
   "Test DCG parsing with very large inputs."
   (eprolog-test--restore-builtins)
@@ -511,13 +511,13 @@ These tests evaluate the DCG system's performance and stability when processing 
     (condition-case nil
         (should-not (eprolog-test--has-solution-p `((phrase large-list ,mixed-input))))
       (error t))))
-#+END_SRC
+#+end_SRC
 
 *** Left Recursion Detection
 
 Left recursion represents one of the most challenging aspects of parsing system design. These tests verify that the DCG system handles left-recursive grammars appropriately, either through transformation techniques or controlled failure.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-left-recursion ()
   "Test handling of left-recursive grammars."
   (eprolog-test--restore-builtins)
@@ -542,13 +542,13 @@ Left recursion represents one of the most challenging aspects of parsing system 
   (condition-case nil
       (eprolog-test--has-solution-p '((phrase indirect-a ("x" "y"))))
     (error t))) ;; Accept controlled failure
-#+END_SRC
+#+end_SRC
 
 *** Invalid Terminal/Non-terminal Mixing
 
 This subsection tests the system's handling of malformed grammar rules that mix invalid terminal and non-terminal constructs, ensuring robust error detection and appropriate failure modes.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-feature-dcg-invalid-mixing ()
   "Test error handling with invalid terminal/non-terminal combinations."
   (eprolog-test--restore-builtins)
@@ -574,4 +574,4 @@ This subsection tests the system's handling of malformed grammar rules that mix 
   
   (should-not (eprolog-test--has-solution-p 
     '((phrase invalid-semantic-action ("test" "end"))))))
-#+END_SRC
+#+end_SRC

--- a/docs/dynamic-parameters.org
+++ b/docs/dynamic-parameters.org
@@ -1,0 +1,316 @@
+#+TITLE: Dynamic Parameters
+#+AUTHOR: Masaya Taniguchi
+#+PROPERTY: header-args:emacs-lisp :tangle yes
+
+* Dynamic Parameters
+
+Dynamic parameters provide a sophisticated stateful mechanism for maintaining and sharing data across different parts of a Prolog computation. They bridge the gap between Prolog's typically stateless nature and practical needs for accumulating results, counters, and complex data sharing.
+
+** Core Predicates
+
+*** ~store/2~: Store a value with backtracking support
+~store(Key, Value)~ stores ~Value~ under ~Key~ in the dynamic parameter store. The value persists during forward execution and is automatically restored to its previous state when backtracking occurs above the store operation.
+
+*** ~fetch/2~: Retrieve stored values  
+~fetch(Key, Variable)~ retrieves the value associated with ~Key~ and unifies it with ~Variable~. Fails if the key doesn't exist in the current parameter context.
+
+** Key Features
+
+- **Backtracking-Aware**: Parameter values are automatically restored during backtracking
+- **Scoped Storage**: Each store operation creates a new parameter scope
+- **Lisp Integration**: Values can be any Lisp data structure
+- **Query-Local**: Parameters exist only within the current query execution
+- **Deterministic Access**: fetch/2 is deterministic - succeeds once or fails
+
+** Common Use Cases
+
+1. **Counters and Accumulators**: Maintaining running totals across recursive predicates
+2. **State Machines**: Tracking current state in complex logic
+3. **Caching**: Storing computed values for reuse within a query
+4. **Inter-Predicate Communication**: Sharing data between unrelated predicates
+5. **Configuration**: Passing settings through deep call stacks
+
+** Usage Examples
+
+*** Basic Storage and Retrieval
+#+begin_src emacs-lisp :eval never :tangle no
+;; Store a simple value
+(eprolog-query '((store user-id 12345)
+                 (fetch user-id _id)
+                 (lisp _result (format "User: %d" _id))))
+;; Result: _result = "User: 12345"
+#+end_src
+
+*** Counter Pattern
+#+begin_src emacs-lisp :eval never :tangle no
+;; Initialize and increment a counter
+(eprolog-define-predicate (increment-counter _new-value)
+  (fetch counter _current)
+  (is _new-value (+ _current 1))
+  (store counter _new-value))
+
+(eprolog-query '((store counter 0)
+                 (increment-counter _val1)  ; Sets counter to 1
+                 (increment-counter _val2)  ; Sets counter to 2
+                 (fetch counter _final)))   ; _final = 2
+#+end_src
+
+*** Backtracking Behavior
+#+begin_src emacs-lisp :eval never :tangle no
+;; Demonstrates automatic restoration during backtracking
+(eprolog-query '((store level start)
+                 (or (and (store level branch-a)
+                          (fetch level _val))     ; _val = branch-a
+                     (and (store level branch-b)  
+                          (fetch level _val))     ; _val = branch-b
+                     (fetch level _val))))       ; _val = start (restored)
+;; Produces 3 solutions: branch-a, branch-b, start
+#+end_src
+
+*** Complex Data Structures
+#+begin_src emacs-lisp :eval never :tangle no
+;; Store and manipulate complex Lisp data
+(eprolog-query '((store config (list :debug t :max-depth 10))
+                 (fetch config _cfg)
+                 (lisp _debug-mode (plist-get _cfg :debug))
+                 (lisp _max (plist-get _cfg :max-depth))))
+#+end_src
+
+** Best Practices
+
+*** Use Descriptive Keys
+#+begin_src emacs-lisp :eval never :tangle no
+;; Good: Descriptive key names
+(store user-preferences (list :theme dark :font-size 12))
+(store current-search-depth 5)
+
+;; Avoid: Generic or unclear keys  
+(store x 42)
+(store temp-var some-value)
+#+end_src
+
+*** Initialize Before Use
+#+begin_src emacs-lisp :eval never :tangle no
+;; Always initialize parameters at query start
+(eprolog-define-predicate (process-with-counter _items _result)
+  (store item-count 0)           ; Initialize counter
+  (process-list _items _result)) ; Then process
+#+end_src
+
+*** Handle Missing Keys Gracefully
+#+begin_src emacs-lisp :eval never :tangle no
+;; Use default values for optional parameters
+(eprolog-define-predicate (get-config-value _key _value)
+  (or (fetch _key _value)           ; Try to fetch
+      (= _value default-value)))    ; Use default if not found
+#+end_src
+
+** Backtracking Semantics
+
+The store/fetch mechanism implements **scoped parameter restoration**: when backtracking occurs, parameter values are restored to their state at the time of the choice point, not completely removed. This creates a stack-like behavior where each choice point preserves its parameter context.
+
+#+begin_src emacs-lisp :eval never :tangle no
+;; Example demonstrating scoped restoration
+(eprolog-query 
+  '((store level 0)                    ; Initial: level=0
+    (or (and (store level 1)           ; Branch 1: level=1
+             (or (store level 2)       ;   Sub-branch: level=2
+                 (store level 3))      ;   Sub-branch: level=3  
+             (fetch level _inner))     ; _inner gets 2 or 3
+        (fetch level _outer))))        ; _outer gets 0 (restored)
+;; Solutions: _inner=2, _inner=3, _outer=0
+#+end_src
+
+** Integration with Lisp
+
+Dynamic parameters seamlessly integrate with Lisp evaluation, allowing storage and retrieval of any Lisp data structure:
+
+#+begin_src emacs-lisp :eval never :tangle no
+;; Store complex Lisp structures
+(eprolog-query '((lisp _hash (make-hash-table))
+                 (store shared-data _hash)
+                 (fetch shared-data _retrieved)
+                 (lisp! (puthash 'key 'value _retrieved))))
+
+;; Store and retrieve functions
+(eprolog-query '((store formatter (lambda (x) (format "Value: %s" x)))
+                 (fetch formatter _fn)
+                 (lisp _result (funcall _fn 42))))
+#+end_src
+
+** Core Functionality Tests
+
+The following tests demonstrate and validate the fundamental behavior of dynamic parameters:
+
+#+begin_src emacs-lisp
+(ert-deftest eprolog-feature-lisp-dynamic-parameters ()
+  "Test core dynamic parameter functionality including storage, retrieval, and backtracking."
+  (eprolog-test--restore-builtins)
+
+  ;; Test store and fetch
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store test-key 42)
+             (fetch test-key _value)
+             (= _value 42)))))
+    (should (= (length solutions) 1))
+    (should (= (cdr (assoc '_value (car solutions))) 42)))
+
+  ;; Test parameter persistence across goals
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store counter 0)
+             (fetch counter _old)
+             (is _new (+ _old 1))
+             (store counter _new)
+             (fetch counter 1)))))
+    (should (= (length solutions) 1)))
+
+  ;; Test backtracking restores previous values
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store a 0)
+             (or (store a 1) true)
+             (fetch a _v)))))
+    (should (= (length solutions) 2))
+    (should (equal (mapcar (lambda (sol) (cdr (assoc '_v sol))) solutions)
+                  '(1 0)))))
+#+end_src
+
+* Advanced Store/Fetch Backtracking Tests
+
+The store/fetch mechanism must handle complex backtracking scenarios correctly, ensuring that parameter values are properly restored when execution backtracks above store operations.
+
+#+begin_src emacs-lisp
+(ert-deftest eprolog-feature-store-fetch-advanced-backtracking ()
+  "Test comprehensive backtracking scenarios for store/fetch predicates."
+  (eprolog-test--restore-builtins)
+
+  ;; === TEST 1: Nested backtracking with multiple store operations ===
+  ;; This tests that stores at different backtrack points are restored correctly
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store level 0)
+             (or (and (store level 1)
+                      (or (store level 2) (store level 3))
+                      (fetch level _v))
+                 (fetch level _v))))))
+    (should (= (length solutions) 3))
+    ;; Should get: level=2, level=3, level=0
+    (let ((values (mapcar (lambda (sol) (cdr (assoc '_v sol))) solutions)))
+      (should (equal (sort values #'<) '(0 2 3)))))
+
+  ;; === TEST 2: Complex choice points with store operations ===
+  ;; Test store operations inside multiple choice alternatives
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store base 100)
+             (member _x (1 2 3))
+             (lisp _offset (* _x 10))
+             (store temp _offset)
+             (fetch base _base)
+             (fetch temp _temp)
+             (is _result (+ _base _temp))))))
+    (should (= (length solutions) 3))
+    (let ((results (mapcar (lambda (sol) (cdr (assoc '_result sol))) solutions)))
+      (should (equal (sort results #'<) '(110 120 130)))))
+
+  ;; === TEST 3: Deep backtracking chains ===
+  ;; Multiple levels of nested backtracking with parameter restoration
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store depth 0)
+             (or (and (store depth 1)
+                      (or (and (store depth 2)
+                               (or (store depth 3) (store depth 4)))
+                          (store depth 5)))
+                 (store depth 6))
+             (fetch depth _final)))))
+    (should (= (length solutions) 4))
+    (let ((depths (mapcar (lambda (sol) (cdr (assoc '_final sol))) solutions)))
+      (should (equal (sort depths #'<) '(3 4 5 6)))))
+
+  ;; === TEST 4: Store same key multiple times in different branches ===
+  ;; Ensure proper restoration when same key is stored multiple times
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store counter 0)
+             (or (and (store counter 10)
+                      (store counter 11)
+                      (fetch counter _value))
+                 (and (store counter 20)
+                      (store counter 21) 
+                      (fetch counter _value))
+                 (fetch counter _value))))))
+    (should (= (length solutions) 3))
+    (let ((values (mapcar (lambda (sol) (cdr (assoc '_value sol))) solutions)))
+      (should (equal (sort values #'<) '(0 11 21)))))
+
+  ;; === TEST 5: Backtracking with failed fetch operations ===
+  ;; Test behavior when fetch operations fail during backtracking
+  ;; The successful branch should produce one solution, failed fetch should be unbound
+  (let ((solutions (eprolog-test--collect-solutions
+           '((or (and (store temp-key 42)
+                      (fetch temp-key _success))
+                 (fetch nonexistent-key _fail))))))
+    (should (= (length solutions) 1))
+    (should (= (cdr (assoc '_success (car solutions))) 42))
+    ;; The _fail variable should be unbound (equal to itself) since that branch failed
+    (should (eq (cdr (assoc '_fail (car solutions))) '_fail)))
+
+  ;; === TEST 6: Complex data structures in backtracking ===
+  ;; Test backtracking with complex stored values
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store data (initial))
+             (member _item (a b c))
+             (lisp _new_data (list 'updated '_item))
+             (store data _new_data)
+             (fetch data _result)))))
+    (should (= (length solutions) 3))
+    (let ((results (mapcar (lambda (sol) (cdr (assoc '_result sol))) solutions)))
+      (should (equal results '((updated a) (updated b) (updated c))))))
+
+  ;; === TEST 7: Store operations followed by cuts ===
+  ;; Test that cuts don't interfere with parameter restoration
+  (eprolog-define-predicate (cut-test _result)
+    (store cut-test-key 1)
+    (member _x (a b c))
+    (= _x b)
+    !
+    (fetch cut-test-key _result))
+  
+  (let ((solutions (eprolog-test--collect-solutions '((cut-test _val)))))
+    (should (= (length solutions) 1))
+    (should (= (cdr (assoc '_val (car solutions))) 1)))
+
+  ;; === TEST 8: Multiple independent parameter stores ===
+  ;; Test multiple parameters being stored and restored independently
+  (let ((solutions (eprolog-test--collect-solutions
+           '((store x 10)
+             (store y 20)
+             (or (and (store x 11) (store y 21) (fetch x _x1) (fetch y _y1))
+                 (and (store x 12) (fetch x _x2) (fetch y _y2))
+                 (and (fetch x _x3) (fetch y _y3)))))))
+    (should (= (length solutions) 3))
+    ;; Verify each solution has the correct parameter values
+    (let* ((sol1 (nth 0 solutions))
+           (sol2 (nth 1 solutions))
+           (sol3 (nth 2 solutions)))
+      (should (and (= (cdr (assoc '_x1 sol1)) 11) (= (cdr (assoc '_y1 sol1)) 21)))
+      (should (and (= (cdr (assoc '_x2 sol2)) 12) (= (cdr (assoc '_y2 sol2)) 20)))
+      (should (and (= (cdr (assoc '_x3 sol3)) 10) (= (cdr (assoc '_y3 sol3)) 20))))))
+#+end_src
+
+* Dynamic Parameters Negative Tests
+
+Dynamic parameter predicates should fail with invalid keys or expressions:
+
+#+begin_src emacs-lisp
+(ert-deftest eprolog-feature-lisp-fetch-negative-tests ()
+  "Test negative cases for fetch predicate."
+  (eprolog-test--restore-builtins)
+  
+  ;; Getting non-existent keys should fail
+  (should-not (eprolog-test--has-solution-p '((fetch nonexistent-key _value))))
+  (should-not (eprolog-test--has-solution-p '((fetch missing-key _x))))
+  
+  ;; Unification failures with retrieved values
+  (let ((solutions (eprolog-test--collect-solutions '((store test-key 42)))))
+    (should (= (length solutions) 1)))
+  (should-not (eprolog-test--has-solution-p '((fetch test-key "forty-two"))))
+  (should-not (eprolog-test--has-solution-p '((fetch test-key (a b c))))))
+#+end_src
+

--- a/docs/examples.org
+++ b/docs/examples.org
@@ -26,7 +26,7 @@ This subsection covers:
 
 The following test establishes a comprehensive family tree covering all relationship types and complex queries:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-family-tree-comprehensive ()
   "Test comprehensive family tree with all relationship types and complex queries."
   (eprolog-test--restore-builtins)
@@ -150,7 +150,7 @@ The following test establishes a comprehensive family tree covering all relation
     (should (member '((_x . katsuo) (_y . sazae)) solutions))
     (should (member '((_x . katsuo) (_y . wakame)) solutions))
     (should (member '((_x . sazae) (_y . wakame)) solutions))))
-#+END_SRC
+#+end_SRC
 
 The family tree test demonstrates how basic facts can be combined with rules to derive complex relationships, showcasing the power of logical inference in Prolog.
 
@@ -162,7 +162,7 @@ Understanding backtracking is essential for mastering Prolog. This section explo
 
 The cut operator provides fine-grained control over Prolog's backtracking mechanism:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-complex-backtracking-with-cut ()
   "Test complex backtracking scenarios with cut."
   (eprolog-test--restore-builtins)
@@ -184,11 +184,11 @@ The cut operator provides fine-grained control over Prolog's backtracking mechan
   (let ((solutions (eprolog-test--collect-solutions '((first-color _x)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_x (car solutions))) 'red))))
-#+END_SRC
+#+end_SRC
 
 The repeat predicate combined with cut creates controlled loops:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-repeat-with-complex-conditions ()
   "Test repeat predicate with complex termination conditions."
   (eprolog-test--restore-builtins)
@@ -203,7 +203,7 @@ The repeat predicate combined with cut creates controlled loops:
     
     (should (eprolog-test--has-solution-p '((test-repeat-complex))))
     (should (= counter 5))))
-#+END_SRC
+#+end_SRC
 
 ** Advanced Applications
 
@@ -213,7 +213,7 @@ The true test of any programming paradigm lies in its ability to express complex
 
 Factorial calculation demonstrates basic recursion in Prolog:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-factorial ()
   "Test recursive factorial implementation."
   (eprolog-test--restore-builtins)
@@ -238,11 +238,11 @@ Factorial calculation demonstrates basic recursion in Prolog:
   (let ((solutions (eprolog-test--collect-solutions '((factorial 5 _f)))))
     (should (= (length solutions) 1))
     (should (= (cdr (assoc '_f (car solutions))) 120))))
-#+END_SRC
+#+end_SRC
 
 The Fibonacci sequence shows more complex recursive patterns:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-fibonacci ()
   "Test Fibonacci sequence implementation."
   (eprolog-test--restore-builtins)
@@ -270,11 +270,11 @@ The Fibonacci sequence shows more complex recursive patterns:
   
   (let ((solutions (eprolog-test--collect-solutions '((fib 4 _f)))))
     (should (= (cdr (assoc '_f (car solutions))) 3))))
-#+END_SRC
+#+end_SRC
 
 The Greatest Common Divisor algorithm demonstrates iterative computation in Prolog:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-gcd-algorithm ()
   "Test Greatest Common Divisor algorithm."
   (eprolog-test--restore-builtins)
@@ -292,7 +292,7 @@ The Greatest Common Divisor algorithm demonstrates iterative computation in Prol
   
   (let ((solutions (eprolog-test--collect-solutions '((gcd 15 25 _g)))))
     (should (= (cdr (assoc '_g (car solutions))) 5))))
-#+END_SRC
+#+end_SRC
 
 ** Performance Testing
 
@@ -308,7 +308,7 @@ Key performance dimensions evaluated:
 
 Comprehensive performance testing evaluates multiple aspects of system performance:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-performance-tests ()
   "Test performance with larger databases and deep recursion."
   (eprolog-test--restore-builtins)
@@ -341,11 +341,11 @@ Comprehensive performance testing evaluates multiple aspects of system performan
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_result (car solutions))) 'done))))
   
-#+END_SRC
+#+end_SRC
 
 Additional performance tests focus on specific aspects of system behavior:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-large-database ()
   "Test performance with larger clause database."
   (eprolog-test--restore-builtins)
@@ -354,11 +354,11 @@ Additional performance tests focus on specific aspects of system behavior:
   
   (let ((solutions (eprolog-test--collect-solutions '((test-num _x)))))
     (should (= (length solutions) 100))))
-#+END_SRC
+#+end_SRC
 
 Stress testing pushes the system to its limits:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-stress-testing ()
   "Test system behavior under stress conditions."
   (eprolog-test--restore-builtins)
@@ -381,7 +381,7 @@ Stress testing pushes the system to its limits:
   (let ((solutions (eprolog-test--collect-solutions '((deep-recursion 10 _result)))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_result (car solutions))) 'done))))
-#+END_SRC
+#+end_SRC
 
 ** Integration and End-to-End Tests
 
@@ -389,7 +389,7 @@ These tests verify complete workflows and interactions between different ε-prol
 
 *** Multi-Module Integration Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-multi-feature-integration ()
   "Test integration of multiple ε-prolog features in a single workflow."
   (eprolog-test--restore-builtins)
@@ -431,11 +431,11 @@ These tests verify complete workflows and interactions between different ε-prol
     (should (= (length solutions) 1)))
   (let ((solutions (eprolog-test--collect-solutions '((age-group charlie middle)))))
     (should (= (length solutions) 1))))
-#+END_SRC
+#+end_SRC
 
 *** Real-World Database Simulation
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-database-simulation ()
   "Test a complete database-like application with multiple tables and relationships."
   (eprolog-test--restore-builtins)
@@ -482,11 +482,11 @@ These tests verify complete workflows and interactions between different ε-prol
     '((employee _id _name engineering _salary) (lispp (> _salary 70000))))))
     (should (>= (length solutions) 1)))
     ;; Should find Alice and Charlie who are in engineering with salary > 70000)
-#+END_SRC
+#+end_SRC
 
 *** Graph Algorithm Integration
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-graph-algorithms ()
   "Test graph algorithms using ε-prolog predicates."
   (eprolog-test--restore-builtins)
@@ -527,7 +527,7 @@ These tests verify complete workflows and interactions between different ε-prol
   (let ((solutions (eprolog-test--collect-solutions '((reachable a d)))))
     (should (>= (length solutions) 1)))
   (should-not (eprolog-test--has-solution-p '((reachable d a)))))
-#+END_SRC
+#+end_SRC
 
 ** Performance Regression Tests
 
@@ -535,7 +535,7 @@ These tests establish performance baselines and detect regression in critical op
 
 *** Basic Operation Performance Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-basic-performance-regression ()
   "Test basic operation performance to detect regressions."
   (eprolog-test--restore-builtins)
@@ -570,11 +570,11 @@ These tests establish performance baselines and detect regression in critical op
     
     (let ((elapsed (float-time (time-subtract (current-time) start-time))))
       (should (< elapsed 2.0))))) ;; 2 seconds threshold
-#+END_SRC
+#+end_SRC
 
 *** Arithmetic Performance Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-arithmetic-performance-regression ()
   "Test arithmetic performance to detect regressions."
   (eprolog-test--restore-builtins)
@@ -605,11 +605,11 @@ These tests establish performance baselines and detect regression in critical op
     
     (let ((elapsed (float-time (time-subtract (current-time) start-time))))
       (should (< elapsed 5.0))))) ;; 5 seconds threshold
-#+END_SRC
+#+end_SRC
 
 *** Backtracking Performance Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_SRC emacs-lisp
 (ert-deftest eprolog-example-backtracking-performance-regression ()
   "Test backtracking performance to detect regressions."
   (eprolog-test--restore-builtins)
@@ -638,4 +638,4 @@ These tests establish performance baselines and detect regression in critical op
     
     (let ((elapsed (float-time (time-subtract (current-time) start-time))))
       (should (< elapsed 0.5)))))) ;; Should be faster with cut
-#+END_SRC
+#+end_SRC

--- a/docs/index.org
+++ b/docs/index.org
@@ -20,7 +20,7 @@ The document draws from practical examples in README.org and the implementation 
 
 Here are the fundamental examples that demonstrate how to define facts, rules, and query the knowledge base:
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_src emacs-lisp :eval never :tangle no
 ;; Define facts (using convenient alias)
 (eprolog-define-predicate (parent tom bob))
 (eprolog-define-predicate (parent tom liz))
@@ -36,11 +36,11 @@ Here are the fundamental examples that demonstrate how to define facts, rules, a
 ;; Query the database
 (eprolog-query (grandparent tom _x))
 ;; Returns: _x = ann, _x = pat
-#+END_SRC
+#+end_src
 
 *** Built-in Predicates Examples
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_src emacs-lisp :eval never :tangle no
 ;; List operations
 (eprolog-query (member _x (a b c)))
 ;; Returns: _x = a, _x = b, _x = c
@@ -53,11 +53,11 @@ Here are the fundamental examples that demonstrate how to define facts, rules, a
 (eprolog-query (atom foo))     ;; Returns: t
 (eprolog-query (number 42))    ;; Returns: t
 (eprolog-query (var _x))       ;; Returns: t
-#+END_SRC
+#+end_src
 
 *** Lisp Integration Examples
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_src emacs-lisp :eval never :tangle no
 ;; Lisp expression evaluation
 (eprolog-query (lisp _result (+ 2 3)))
 ;; Returns: _result = 5
@@ -68,41 +68,47 @@ Here are the fundamental examples that demonstrate how to define facts, rules, a
 
 ;; Side effects
 (eprolog-query (lisp! (message "Hello from Prolog!")))
-#+END_SRC
+#+end_src
 
 ** Running Tests
 
 All examples in this documentation can be executed as tests using ERT (Emacs Lisp Regression Testing):
 
-#+BEGIN_SRC emacs-lisp :eval never :tangle no
+#+begin_src emacs-lisp :eval never :tangle no
 ;; Load the main file and documentation
 (load "eprolog.el")
 (org-babel-load-file "docs/index.org")
 
 ;; Run all tests
 (ert-run-tests-batch-and-exit "eprolog-usage-")
-#+END_SRC
+#+end_src
 
 ** Documentation Structure
 
-This documentation is organized into focused modules, each covering specific aspects of ε-prolog:
+The guide is organized into thematic parts:
 
-- **[[file:api-reference.org][API Reference]]** - Complete function and predicate documentation
-- **[[file:arithmetic.org][Arithmetic and Mathematics]]** - Mathematical operations and comparisons
-- **[[file:builtin-predicates.org][Built-in Predicates]]** - Type checking, list operations, and higher-order predicates  
-- **[[file:control-flow.org][Control Flow]]** - Cut, backtracking, logical operators, and meta-predicates
-- **[[file:core-prolog.org][Core Prolog Functionality]]** - Facts, rules, unification, and basic Prolog operations
-- **[[file:dcg.org][Definite Clause Grammars]]** - Grammar definition and parsing capabilities
-- **[[file:examples.org][Complex Examples]]** - Advanced applications, family trees, and recursive algorithms
-- **[[file:lisp-integration.org][Lisp Integration]]** - Seamless Prolog-Lisp interoperability and dynamic parameters
+*** Part I: Core Concepts
+- [[file:core-prolog.org][Core Prolog Functionality]] - Facts, rules, unification, and basic Prolog operations
+- [[file:builtin-predicates.org][Built-in Predicates]] - Type checking, list operations, and higher-order predicates
+- [[file:control-flow.org][Control Flow]] - Cut, backtracking, logical operators, and meta-predicates
+- [[file:arithmetic.org][Arithmetic and Mathematics]] - Mathematical operations and comparisons
 
-Each module combines comprehensive explanations with executable test cases, ensuring both educational value and system reliability.
+*** Part II: Advanced Features
+- [[file:lisp-integration.org][Lisp Integration]] - Seamless Prolog-Lisp interoperability
+- [[file:dynamic-parameters.org][Dynamic Parameters]] - Stateful data with backtracking-aware semantics
+- [[file:dcg.org][Definite Clause Grammars]] - Grammar definition and parsing capabilities
+
+*** Part III: Examples
+- [[file:examples.org][Complex Examples]] - Advanced applications, family trees, and recursive algorithms
+
+*** Part IV: Reference
+- [[file:api-reference.org][API Reference]] - Complete function and predicate documentation
 
 * Setup
 
 Before exploring the specific modules, let's establish the testing environment that all examples will use:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 ;; Helper function to test query success
 (defun eprolog-test--has-solution-p (goals)
   "Test if GOALS has at least one solution."
@@ -130,4 +136,4 @@ Before exploring the specific modules, let's establish the testing environment t
 (defun eprolog-test--restore-builtins ()
   "Restore built-in predicates and clear user-defined ones."
   (setq eprolog-clause-database (copy-alist eprolog-usage--builtin-predicates)))
-#+END_SRC
+#+end_src

--- a/docs/lisp-integration.org
+++ b/docs/lisp-integration.org
@@ -20,9 +20,22 @@ This subsection covers:
 - ~lisp!/1~ for evaluating Lisp expressions for side effects only
 - How to pass data between Prolog and Lisp
 
+*** Usage Example
+#+begin_src emacs-lisp :eval never :tangle no
+;; Evaluate a Lisp expression and capture result
+(eprolog-query '((lisp _result (+ 2 3))))
+;; _result => 5
+
+;; Use lispp/1 for boolean test
+(eprolog-query '((lispp (> 5 3))))
+
+;; Perform side effects
+(eprolog-query '((lisp! (message "Hello from Lisp!"))))
+#+end_src
+
 The following comprehensive test demonstrates all three main ways to interface with Lisp in a single, well-organized test case:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-integration ()
   "Test comprehensive Lisp integration predicates - all three integration modes."
   (eprolog-test--restore-builtins)
@@ -81,26 +94,26 @@ The following comprehensive test demonstrates all three main ways to interface w
   (let ((solutions (eprolog-test--collect-solutions `((lisp! (setq eprolog-test--counter (+ eprolog-test--counter 1)))))))
     (should (= (length solutions) 1)))
   (should (= eprolog-test--counter 1)))
-#+END_SRC
+#+end_src
 
 ** Lisp Integration Negative Tests
 
 The lisp predicate should fail with invalid expressions and unification failures:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-negative-tests ()
   "Test negative cases for lisp predicate."
   (eprolog-test--restore-builtins)
 
   (should-error (eprolog-test--has-solution-p '((lisp _x (undef)))))
   (should-not (eprolog-test--has-solution-p '((lisp _x (_undef))))))
-#+END_SRC
+#+end_src
 
 ** Lisp Side Effects (lisp!) Negative Tests
 
 The lisp! predicate should fail with invalid expressions:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-side-effects-negative-tests ()
   "Test negative cases for lisp! predicate."
   (eprolog-test--restore-builtins)
@@ -108,13 +121,13 @@ The lisp! predicate should fail with invalid expressions:
   (should-error (eprolog-test--has-solution-p '((lisp! (undef)))))
   (should-not (eprolog-test--has-solution-p '((lisp! (_undef)))))
   )
-#+END_SRC
+#+end_src
 
 ** Lisp Conditional (lispp) Negative Tests
 
 The lispp predicate should fail when expressions return nil or false:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-lispp-negative-tests ()
   "Test negative cases for lispp predicate."
   (eprolog-test--restore-builtins)
@@ -131,319 +144,10 @@ The lispp predicate should fail when expressions return nil or false:
   ;; Complex boolean expressions that evaluate to false
   (should-not (eprolog-test--has-solution-p '((lispp (and t nil)))))
   (should-not (eprolog-test--has-solution-p '((lispp (or nil nil))))))
-#+END_SRC
+#+end_src
 
 ** Dynamic Parameters
-
-Dynamic parameters provide a sophisticated stateful mechanism for maintaining and sharing data across different parts of a Prolog computation. They bridge the gap between Prolog's typically stateless nature and practical needs for accumulating results, counters, and complex data sharing.
-
-*** Core Predicates
-
-**** ~store/2~: Store a value with backtracking support
-~store(Key, Value)~ stores ~Value~ under ~Key~ in the dynamic parameter store. The value persists during forward execution and is automatically restored to its previous state when backtracking occurs above the store operation.
-
-**** ~fetch/2~: Retrieve stored values  
-~fetch(Key, Variable)~ retrieves the value associated with ~Key~ and unifies it with ~Variable~. Fails if the key doesn't exist in the current parameter context.
-
-*** Key Features
-
-- **Backtracking-Aware**: Parameter values are automatically restored during backtracking
-- **Scoped Storage**: Each store operation creates a new parameter scope
-- **Lisp Integration**: Values can be any Lisp data structure
-- **Query-Local**: Parameters exist only within the current query execution
-- **Deterministic Access**: fetch/2 is deterministic - succeeds once or fails
-
-*** Common Use Cases
-
-1. **Counters and Accumulators**: Maintaining running totals across recursive predicates
-2. **State Machines**: Tracking current state in complex logic
-3. **Caching**: Storing computed values for reuse within a query
-4. **Inter-Predicate Communication**: Sharing data between unrelated predicates
-5. **Configuration**: Passing settings through deep call stacks
-
-*** Usage Examples
-
-**** Basic Storage and Retrieval
-#+BEGIN_EXAMPLE
-;; Store a simple value
-(eprolog-query '((store user-id 12345)
-                 (fetch user-id _id)
-                 (lisp _result (format "User: %d" _id))))
-;; Result: _result = "User: 12345"
-#+END_EXAMPLE
-
-**** Counter Pattern
-#+BEGIN_EXAMPLE
-;; Initialize and increment a counter
-(eprolog-define-predicate (increment-counter _new-value)
-  (fetch counter _current)
-  (is _new-value (+ _current 1))
-  (store counter _new-value))
-
-(eprolog-query '((store counter 0)
-                 (increment-counter _val1)  ; Sets counter to 1
-                 (increment-counter _val2)  ; Sets counter to 2
-                 (fetch counter _final)))   ; _final = 2
-#+END_EXAMPLE
-
-**** Backtracking Behavior
-#+BEGIN_EXAMPLE
-;; Demonstrates automatic restoration during backtracking
-(eprolog-query '((store level start)
-                 (or (and (store level branch-a)
-                          (fetch level _val))     ; _val = branch-a
-                     (and (store level branch-b)  
-                          (fetch level _val))     ; _val = branch-b
-                     (fetch level _val))))       ; _val = start (restored)
-;; Produces 3 solutions: branch-a, branch-b, start
-#+END_EXAMPLE
-
-**** Complex Data Structures
-#+BEGIN_EXAMPLE
-;; Store and manipulate complex Lisp data
-(eprolog-query '((store config (list :debug t :max-depth 10))
-                 (fetch config _cfg)
-                 (lisp _debug-mode (plist-get _cfg :debug))
-                 (lisp _max (plist-get _cfg :max-depth))))
-#+END_EXAMPLE
-
-*** Best Practices
-
-**** Use Descriptive Keys
-#+BEGIN_EXAMPLE
-;; Good: Descriptive key names
-(store user-preferences (list :theme dark :font-size 12))
-(store current-search-depth 5)
-
-;; Avoid: Generic or unclear keys  
-(store x 42)
-(store temp-var some-value)
-#+END_EXAMPLE
-
-**** Initialize Before Use
-#+BEGIN_EXAMPLE
-;; Always initialize parameters at query start
-(eprolog-define-predicate (process-with-counter _items _result)
-  (store item-count 0)           ; Initialize counter
-  (process-list _items _result)) ; Then process
-#+END_EXAMPLE
-
-**** Handle Missing Keys Gracefully
-#+BEGIN_EXAMPLE
-;; Use default values for optional parameters
-(eprolog-define-predicate (get-config-value _key _value)
-  (or (fetch _key _value)           ; Try to fetch
-      (= _value default-value)))    ; Use default if not found
-#+END_EXAMPLE
-
-*** Backtracking Semantics
-
-The store/fetch mechanism implements **scoped parameter restoration**: when backtracking occurs, parameter values are restored to their state at the time of the choice point, not completely removed. This creates a stack-like behavior where each choice point preserves its parameter context.
-
-#+BEGIN_EXAMPLE
-;; Example demonstrating scoped restoration
-(eprolog-query 
-  '((store level 0)                    ; Initial: level=0
-    (or (and (store level 1)           ; Branch 1: level=1
-             (or (store level 2)       ;   Sub-branch: level=2
-                 (store level 3))      ;   Sub-branch: level=3  
-             (fetch level _inner))     ; _inner gets 2 or 3
-        (fetch level _outer))))        ; _outer gets 0 (restored)
-;; Solutions: _inner=2, _inner=3, _outer=0
-#+END_EXAMPLE
-
-*** Integration with Lisp
-
-Dynamic parameters seamlessly integrate with Lisp evaluation, allowing storage and retrieval of any Lisp data structure:
-
-#+BEGIN_EXAMPLE
-;; Store complex Lisp structures
-(eprolog-query '((lisp _hash (make-hash-table))
-                 (store shared-data _hash)
-                 (fetch shared-data _retrieved)
-                 (lisp! (puthash 'key 'value _retrieved))))
-
-;; Store and retrieve functions
-(eprolog-query '((store formatter (lambda (x) (format "Value: %s" x)))
-                 (fetch formatter _fn)
-                 (lisp _result (funcall _fn 42))))
-#+END_EXAMPLE
-
-*** Core Functionality Tests
-
-The following tests demonstrate and validate the fundamental behavior of dynamic parameters:
-
-#+BEGIN_SRC emacs-lisp
-(ert-deftest eprolog-feature-lisp-dynamic-parameters ()
-  "Test core dynamic parameter functionality including storage, retrieval, and backtracking."
-  (eprolog-test--restore-builtins)
-
-  ;; Test store and fetch
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store test-key 42)
-             (fetch test-key _value)
-             (= _value 42)))))
-    (should (= (length solutions) 1))
-    (should (= (cdr (assoc '_value (car solutions))) 42)))
-
-  ;; Test parameter persistence across goals
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store counter 0)
-             (fetch counter _old)
-             (is _new (+ _old 1))
-             (store counter _new)
-             (fetch counter 1)))))
-    (should (= (length solutions) 1)))
-
-  ;; Test backtracking restores previous values
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store a 0)
-             (or (store a 1) true)
-             (fetch a _v)))))
-    (should (= (length solutions) 2))
-    (should (equal (mapcar (lambda (sol) (cdr (assoc '_v sol))) solutions)
-                  '(1 0)))))
-#+END_SRC
-
-** Advanced Store/Fetch Backtracking Tests
-
-The store/fetch mechanism must handle complex backtracking scenarios correctly, ensuring that parameter values are properly restored when execution backtracks above store operations.
-
-#+BEGIN_SRC emacs-lisp
-(ert-deftest eprolog-feature-store-fetch-advanced-backtracking ()
-  "Test comprehensive backtracking scenarios for store/fetch predicates."
-  (eprolog-test--restore-builtins)
-
-  ;; === TEST 1: Nested backtracking with multiple store operations ===
-  ;; This tests that stores at different backtrack points are restored correctly
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store level 0)
-             (or (and (store level 1)
-                      (or (store level 2) (store level 3))
-                      (fetch level _v))
-                 (fetch level _v))))))
-    (should (= (length solutions) 3))
-    ;; Should get: level=2, level=3, level=0
-    (let ((values (mapcar (lambda (sol) (cdr (assoc '_v sol))) solutions)))
-      (should (equal (sort values #'<) '(0 2 3)))))
-
-  ;; === TEST 2: Complex choice points with store operations ===
-  ;; Test store operations inside multiple choice alternatives
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store base 100)
-             (member _x (1 2 3))
-             (lisp _offset (* _x 10))
-             (store temp _offset)
-             (fetch base _base)
-             (fetch temp _temp)
-             (is _result (+ _base _temp))))))
-    (should (= (length solutions) 3))
-    (let ((results (mapcar (lambda (sol) (cdr (assoc '_result sol))) solutions)))
-      (should (equal (sort results #'<) '(110 120 130)))))
-
-  ;; === TEST 3: Deep backtracking chains ===
-  ;; Multiple levels of nested backtracking with parameter restoration
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store depth 0)
-             (or (and (store depth 1)
-                      (or (and (store depth 2)
-                               (or (store depth 3) (store depth 4)))
-                          (store depth 5)))
-                 (store depth 6))
-             (fetch depth _final)))))
-    (should (= (length solutions) 4))
-    (let ((depths (mapcar (lambda (sol) (cdr (assoc '_final sol))) solutions)))
-      (should (equal (sort depths #'<) '(3 4 5 6)))))
-
-  ;; === TEST 4: Store same key multiple times in different branches ===
-  ;; Ensure proper restoration when same key is stored multiple times
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store counter 0)
-             (or (and (store counter 10)
-                      (store counter 11)
-                      (fetch counter _value))
-                 (and (store counter 20)
-                      (store counter 21) 
-                      (fetch counter _value))
-                 (fetch counter _value))))))
-    (should (= (length solutions) 3))
-    (let ((values (mapcar (lambda (sol) (cdr (assoc '_value sol))) solutions)))
-      (should (equal (sort values #'<) '(0 11 21)))))
-
-  ;; === TEST 5: Backtracking with failed fetch operations ===
-  ;; Test behavior when fetch operations fail during backtracking
-  ;; The successful branch should produce one solution, failed fetch should be unbound
-  (let ((solutions (eprolog-test--collect-solutions
-           '((or (and (store temp-key 42)
-                      (fetch temp-key _success))
-                 (fetch nonexistent-key _fail))))))
-    (should (= (length solutions) 1))
-    (should (= (cdr (assoc '_success (car solutions))) 42))
-    ;; The _fail variable should be unbound (equal to itself) since that branch failed
-    (should (eq (cdr (assoc '_fail (car solutions))) '_fail)))
-
-  ;; === TEST 6: Complex data structures in backtracking ===
-  ;; Test backtracking with complex stored values
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store data (initial))
-             (member _item (a b c))
-             (lisp _new_data (list 'updated '_item))
-             (store data _new_data)
-             (fetch data _result)))))
-    (should (= (length solutions) 3))
-    (let ((results (mapcar (lambda (sol) (cdr (assoc '_result sol))) solutions)))
-      (should (equal results '((updated a) (updated b) (updated c))))))
-
-  ;; === TEST 7: Store operations followed by cuts ===
-  ;; Test that cuts don't interfere with parameter restoration
-  (eprolog-define-predicate (cut-test _result)
-    (store cut-test-key 1)
-    (member _x (a b c))
-    (= _x b)
-    !
-    (fetch cut-test-key _result))
-  
-  (let ((solutions (eprolog-test--collect-solutions '((cut-test _val)))))
-    (should (= (length solutions) 1))
-    (should (= (cdr (assoc '_val (car solutions))) 1)))
-
-  ;; === TEST 8: Multiple independent parameter stores ===
-  ;; Test multiple parameters being stored and restored independently
-  (let ((solutions (eprolog-test--collect-solutions
-           '((store x 10)
-             (store y 20)
-             (or (and (store x 11) (store y 21) (fetch x _x1) (fetch y _y1))
-                 (and (store x 12) (fetch x _x2) (fetch y _y2))
-                 (and (fetch x _x3) (fetch y _y3)))))))
-    (should (= (length solutions) 3))
-    ;; Verify each solution has the correct parameter values
-    (let* ((sol1 (nth 0 solutions))
-           (sol2 (nth 1 solutions))
-           (sol3 (nth 2 solutions)))
-      (should (and (= (cdr (assoc '_x1 sol1)) 11) (= (cdr (assoc '_y1 sol1)) 21)))
-      (should (and (= (cdr (assoc '_x2 sol2)) 12) (= (cdr (assoc '_y2 sol2)) 20)))
-      (should (and (= (cdr (assoc '_x3 sol3)) 10) (= (cdr (assoc '_y3 sol3)) 20))))))
-#+END_SRC
-
-** Dynamic Parameters Negative Tests
-
-Dynamic parameter predicates should fail with invalid keys or expressions:
-
-#+BEGIN_SRC emacs-lisp
-(ert-deftest eprolog-feature-lisp-fetch-negative-tests ()
-  "Test negative cases for fetch predicate."
-  (eprolog-test--restore-builtins)
-  
-  ;; Getting non-existent keys should fail
-  (should-not (eprolog-test--has-solution-p '((fetch nonexistent-key _value))))
-  (should-not (eprolog-test--has-solution-p '((fetch missing-key _x))))
-  
-  ;; Unification failures with retrieved values
-  (let ((solutions (eprolog-test--collect-solutions '((store test-key 42)))))
-    (should (= (length solutions) 1)))
-  (should-not (eprolog-test--has-solution-p '((fetch test-key "forty-two"))))
-  (should-not (eprolog-test--has-solution-p '((fetch test-key (a b c))))))
-#+END_SRC
+For stateful parameter storage and backtracking semantics, see [[file:dynamic-parameters.org][Dynamic Parameters]].
 
 ** Advanced Lisp Integration Error Handling
 
@@ -451,7 +155,7 @@ These tests verify robust error handling in complex Lisp integration scenarios.
 
 *** Invalid Lisp Expression Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-invalid-expressions ()
   "Test error handling with malformed Lisp expressions."
   (eprolog-test--restore-builtins)
@@ -468,11 +172,11 @@ These tests verify robust error handling in complex Lisp integration scenarios.
   ;; Test lisp!/1 with side-effect expressions that fail (may fail or error)
   (should-error (eprolog-test--has-solution-p '((lisp! (error "Intentional error")))))
   (should-error (eprolog-test--has-solution-p '((lisp! (setq undefined-variable undefined-other))))))
-#+END_SRC
+#+end_src
 
 *** Large Data Transfer Tests
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-large-data-transfer ()
   "Test passing large data structures between Prolog and Lisp."
   (eprolog-test--restore-builtins)
@@ -494,11 +198,11 @@ These tests verify robust error handling in complex Lisp integration scenarios.
       (let ((solutions (eprolog-test--collect-solutions `((lisp _result (length ',test-data))))))
         (should (= (length solutions) 1))
         (should (= (cdr (assoc '_result (car solutions))) 100))))))
-#+END_SRC
+#+end_src
 
 *** Type Conversion Edge Cases
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-type-conversion-edge-cases ()
   "Test edge cases in type conversion between Prolog and Lisp."
   (eprolog-test--restore-builtins)
@@ -541,11 +245,11 @@ These tests verify robust error handling in complex Lisp integration scenarios.
   (let ((solutions (eprolog-test--collect-solutions '((lisp _result "unicode: αβγδε")))))
     (should (= (length solutions) 1))
     (should (equal (cdr (assoc '_result (car solutions))) "unicode: αβγδε"))))
-#+END_SRC
+#+end_src
 
 *** Nested Lisp Calls and Complex Integration
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
 (ert-deftest eprolog-feature-lisp-nested-complex-integration ()
   "Test complex nested Lisp integration scenarios."
   (eprolog-test--restore-builtins)
@@ -581,4 +285,4 @@ These tests verify robust error handling in complex Lisp integration scenarios.
   (condition-case nil
       (eprolog-test--has-solution-p '((error-recovery-test _result)))
     (error t))) ;; Accept controlled failure
-#+END_SRC
+#+end_src


### PR DESCRIPTION
## Summary
- reorganize documentation into thematic parts and add dynamic parameters chapter
- add non-test usage examples and convert sample blocks to org src syntax
- reference dynamic parameters chapter from Lisp integration docs
- normalize Org block keywords to lowercase across documentation

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68ac05ffd0988322a180899689507e6e